### PR TITLE
Set scrum board column widths according to issue percentages

### DIFF
--- a/Scrum/pages/board.php
+++ b/Scrum/pages/board.php
@@ -131,6 +131,22 @@ else
 	$resolved_percent = 0;
 }
 
+$bug_percentage_by_column = array();
+foreach ( $columns as $column => $statuses )
+{
+	$bug_count_for_column = 0;
+
+	foreach ( $statuses as $l_status )
+	{
+		if ( array_key_exists( $l_status, $bugs) )
+		{
+			$bug_count_for_column += count( $bugs[$l_status] );
+		}
+	}
+
+	$bug_percentage_by_column[$column] = ( $bug_count_for_column / $bug_count ) * 100;
+}
+
 if ($target_version)
 {
 	foreach($project_ids as $project_id)
@@ -236,7 +252,7 @@ html_page_top(plugin_lang_get("board"));
 <tr class="row-1">
 
 <?php foreach ($columns as $column => $statuses): ?>
-<td class="scrumcolumn">
+<td class="scrumcolumn" width="<?php echo $bug_percentage_by_column[$column] ?>%">
 <?php $first = true; foreach ($statuses as $status): ?>
 <?php if (isset($bugs[$status]) || plugin_config_get("show_empty_status")): ?>
 <?php if ($first): $first = false; else: ?>


### PR DESCRIPTION
Allowing the columns to have widths set as percentages of the issues
show in the column from the total issues gives better results in terms
of layout.

There is still room for improvement, as the percentages may not be
multiples of the size of the scrum cards, but I don't see how this can
be done without using Javascript to detect the client's viewport
dimensions.

Tested on FireFox 6, Opera 11, Chromium 15 and IE 9 ( including
IE 8 mode ).

Fixes #222: Scrum board columns do not always fill all available space
